### PR TITLE
add documentation from example to codebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+# Continuous Integration (CI) is the practice, in software
+# engineering, of merging all developer working copies with a shared mainline
+# several times a day < https://docs.platformio.org/page/ci/index.html >
+#
+# Documentation:
+#
+# * Travis CI Embedded Builds with PlatformIO
+#   < https://docs.travis-ci.com/user/integration/platformio/ >
+#
+# * PlatformIO integration with Travis CI
+#   < https://docs.platformio.org/page/ci/travis.html >
+#
+# * User Guide for `platformio ci` command
+#   < https://docs.platformio.org/page/userguide/cmd_ci.html >
+#
+#
+# Please choose one of the following templates (proposed below) and uncomment
+# it (remove "# " before each line) or use own configuration according to the
+# Travis CI documentation (see above).
+#
+
+language: python
+python:
+  - "2.7"
+
+# Cache PlatformIO packages using Travis CI container-based infrastructure
+sudo: false
+cache:
+  directories:
+    - "~/.platformio"
+    - $HOME/.cache/pip
+
+env:
+  - PLATFORMIO_CI_SRC=examples/Single_Shot/Single_Shot.ino
+
+install:
+  - pip install -U platformio pip setuptools
+  - platformio update
+
+script:
+  - platformio ci --board=esp-wrover-kit

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": [
+        "platformio.platformio-ide"
+    ]
+}

--- a/src/ADS1115_WE.h
+++ b/src/ADS1115_WE.h
@@ -2,17 +2,17 @@
  *
  * This is a library for the ADS1115 A/D Converter
  *
- * You'll find several example sketches which should enable you to use the library. 
+ * You'll find several example sketches which should enable you to use the library.
  *
  * You are free to use it, change it or build on it. In case you like it, it would
  * be cool if you give it a star.
  *
  * If you find bugs, please inform me!
- * 
+ *
  * Written by Wolfgang (Wolle) Ewald
  * https://wolles-elektronikkiste.de
  *
- * 
+ *
  ******************************************************************************/
 
 #ifndef ADS1115_WE_H_
@@ -30,7 +30,7 @@
 #define ADS1115_CONV_REG 		0x00 //Conversion Register
 #define ADS1115_CONFIG_REG    	0x01 //Configuration Register
 #define ADS1115_LO_THRESH_REG   0x02 //Low Threshold Register
-#define ADS1115_HI_THRESH_REG   0x03 //High Threshold Register 
+#define ADS1115_HI_THRESH_REG   0x03 //High Threshold Register
 
 /* other */
 #define ADS1115_REG_FACTOR 32768
@@ -49,7 +49,7 @@ typedef enum ADS1115_LATCH {
 } latch;
 
 typedef enum ADS1115_ALERT_POL {
-	ADS1115_ACT_LOW  = 0x0000,   
+	ADS1115_ACT_LOW  = 0x0000,
 	ADS1115_ACT_HIGH = 0x0008
 } alertPol;
 
@@ -102,28 +102,113 @@ typedef enum ADS1115_STATUS_OR_START{
 
 class ADS1115_WE
 {
-public:	
+public:
 	ADS1115_WE(int addr);
-	ADS1115_WE();			//sets default I2C Address 0x48
-  
+	ADS1115_WE(); // uses default I2C Address 0x48
+
 	void reset();
 	bool init();
+
+	/* Set number of conversions after which the alert pin will be active
+     * - or you can disable the alert
+     *
+     *  ADS1115_ASSERT_AFTER_1  -> after 1 conversion
+     *  ADS1115_ASSERT_AFTER_2  -> after 2 conversions
+     *  ADS1115_ASSERT_AFTER_4  -> after 4 conversions
+     *  ADS1115_DISABLE_ALERT   -> disable comparator // alert pin (default)
+    */
 	void setAlertPinMode(ADS1115_COMP_QUE mode);
+
+	/* Enable or disable latch. If latch is enabled the alarm pin will be active until the
+     * conversion register is read (getResult functions). If disabled the alarm pin will be
+     * deactivated with next value within limits.
+     *
+     * ADS1115_LATCH_DISABLED (default)
+     * ADS1115_LATCH_ENABLED
+    */
 	void setAlertLatch(ADS1115_LATCH latch);
+
+	/* Sets the alert pin polarity if active:
+     *
+     * Enable or disable latch. If latch is enabled the alarm pin will be active until the
+     * conversion register is read (getResult functions). If disabled the alarm pin will be
+     * deactivated with next value within limits.
+     *
+     * ADS1115_ACT_LOW  ->  active low (default)
+     * ADS1115_ACT_HIGH ->  active high
+    */
 	void setAlertPol(ADS1115_ALERT_POL polarity);
+
+	/* Choose maximum limit or maxium and minimum alert limit (window)in Volt - alert pin will
+     * be active when measured values are beyond the maximum limit or outside the window
+     * Upper limit first: setAlertLimit_V(MODE, maximum, minimum)
+     * In max limit mode the minimum value is the limit where the alert pin will be deactivated (if
+     * not latched)
+     *
+     * ADS1115_MAX_LIMIT
+     * ADS1115_WINDOW
+    */
 	void setAlertModeAndLimit_V(ADS1115_COMP_MODE mode, float hithres, float lothres);
+
+	/* Set the conversion rate in SPS (samples per second)
+     * Options should be self-explaining:
+     *
+     * ADS1115_8_SPS
+     * ADS1115_16_SPS
+     * ADS1115_32_SPS
+     * ADS1115_64_SPS
+     * ADS1115_128_SPS (default)
+     * ADS1115_250_SPS
+     * ADS1115_475_SPS
+     * ADS1115_860_SPS
+    */
 	void setConvRate(ADS1115_CONV_RATE rate);
+
+	/* Set continous or single shot mode:
+     *
+     * ADS1115_CONTINOUS  ->  continous mode
+     * ADS1115_SINGLE     ->  single shot mode (default)
+    */
 	void setMeasureMode(ADS1115_MEASURE_MODE mode);
+
+	/*
+	 * Set the voltage range of the ADC to adjust the gain
+	 * Please note that you must not apply more than VDD + 0.3V to the input pins!
+	 *
+	 * ADS1115_RANGE_6144  ->  +/- 6144 mV
+	 * ADS1115_RANGE_4096  ->  +/- 4096 mV
+	 * ADS1115_RANGE_2048  ->  +/- 2048 mV (default)
+	 * ADS1115_RANGE_1024  ->  +/- 1024 mV
+	 * ADS1115_RANGE_0512  ->  +/- 512 mV
+	 * ADS1115_RANGE_0256  ->  +/- 256 mV
+	*/
 	void setVoltageRange_mV(ADS1115_RANGE range);
+
+	/* Set the inputs to be compared
+     *
+     * ADS1115_COMP_0_1    ->  compares 0 with 1 (default)
+     * ADS1115_COMP_0_3    ->  compares 0 with 3
+     * ADS1115_COMP_1_3    ->  compares 1 with 3
+     * ADS1115_COMP_2_3    ->  compares 2 with 3
+     * ADS1115_COMP_0_GND  ->  compares 0 with GND
+     * ADS1115_COMP_1_GND  ->  compares 1 with GND
+     * ADS1115_COMP_2_GND  ->  compares 2 with GND
+     * ADS1115_COMP_3_GND  ->  compares 3 with GND
+    */
 	void setCompareChannels(ADS1115_MUX mux);
+
 	bool isBusy();
 	void startSingleMeasurement();
 	float getResult_V();
 	float getResult_mV();
+
+	/* With this function the alert pin will be active, when a conversion is ready.
+     * In order to deactivate, use the setAlertLimit_V function
+    */
 	void setAlertPinToConversionReady();
 	void clearAlert();
-	
-		
+
+
 private:
 	uint16_t voltageRange;
 	ADS1115_MEASURE_MODE deviceMeasureMode;


### PR DESCRIPTION
you added such lovely documentation to the example, but the actual code has no documentation at all. I think maintaining the documentation in many examples, and duplicating it, makes it hard to maintain so I would suggest to shorten the docs in the examples and properly maintain docs in codebase.

My editor also removed trailing whitespace, would be good if yours does the same.