### PR TITLE
add a non blocking function to set compare channel

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -36,6 +36,7 @@ setMeasureMode	KEYWORD2
 setVoltageRange_mV	KEYWORD2
 setAutoRange	KEYWORD2
 setCompareChannels	KEYWORD2
+setCompareChannels_nonblock	KEYWORD2
 isBusy	KEYWORD2
 startSingleMeasurement	KEYWORD2
 getResult_V	KEYWORD2

--- a/src/ADS1115_WE.cpp
+++ b/src/ADS1115_WE.cpp
@@ -237,6 +237,13 @@ void ADS1115_WE::setCompareChannels(ADS1115_MUX mux){
     }       
 }
 
+void ADS1115_WE::setCompareChannels_nonblock(ADS1115_MUX mux){
+    uint16_t currentConfReg = readRegister(ADS1115_CONFIG_REG);
+    currentConfReg &= ~(0xF000);    
+    currentConfReg |= (mux);
+    writeRegister(ADS1115_CONFIG_REG, currentConfReg);
+}
+
 void ADS1115_WE::setSingleChannel(size_t channel) {
     if (channel >=  4)
         return;

--- a/src/ADS1115_WE.h
+++ b/src/ADS1115_WE.h
@@ -230,6 +230,10 @@ class ADS1115_WE
         */
         void setCompareChannels(ADS1115_MUX mux);
 
+        /* Set to channel (0-3) in single ended mode in a non blocking way without delay
+         */
+        void setCompareChannels_nonblock(ADS1115_MUX mux);
+
         /* Set to channel (0-3) in single ended mode
          */
         void setSingleChannel(size_t channel);


### PR DESCRIPTION
In continuous mode the provided set compare channel function implements a delay to guarantee the correct adc value.

In microcontroller tasks with multiple simultaneous tasks this delay is a problem because it blocks other tasks. So I added an additional non blocking function to set compare channel. This is only for advanced users because the user has to take care to wait an appropriate time until the adc value is valid.

Nevertheless I hope you could accept this pull request.

Thank you.